### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "zed_kotlin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_kotlin"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "kotlin"
 name = "Kotlin"
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = ["evrsen", "cholwell"]
 description = "Kotlin language support."


### PR DESCRIPTION
This PR bumps the version of this extension to v0.1.3

Includes:
- https://github.com/zed-extensions/kotlin/pull/37
- https://github.com/zed-extensions/kotlin/pull/38