### PR TITLE
Add overrides, doc comments and more brackets

### DIFF
--- a/languages/kotlin/config.toml
+++ b/languages/kotlin/config.toml
@@ -4,7 +4,11 @@ path_suffixes = ["kt", "kts"]
 line_comments = ["// "]
 brackets = [
     { start = "(", end = ")", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
     { start = "{", end = "}", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
+block_comment = { start = "/*", prefix = "", end = "*/", tab_size = 0 }
+documentation_comment = { start = "/**", prefix = "* ", end = "*/", tab_size = 1 }

--- a/languages/kotlin/overrides.scm
+++ b/languages/kotlin/overrides.scm
@@ -1,0 +1,6 @@
+[
+  (line_comment)
+  (multiline_comment)
+] @comment.inclusive
+
+(string_literal) @string


### PR DESCRIPTION
Closes https://github.com/zed-extensions/kotlin/issues/28

This PR adds a basic `overrides.scm` as well as support for doc comments.