### PR TITLE
Update README.md, k should be uppercased in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use Kotlin LSP instead of the Kotlin Language Server, you must explicity enab
 ```json
 {
   "languages": {
-    "kotlin": {
+    "Kotlin": {
       "language_servers": ["kotlin-lsp"]
     }
   }


### PR DESCRIPTION
I initially copy the config from Readme and things are not as expected. change the `k` to uppercase do the work.