### PR TITLE
Add comment language injections

### DIFF
--- a/languages/kotlin/injections.scm
+++ b/languages/kotlin/injections.scm
@@ -1,2 +1,5 @@
-((comment) @content
+([
+  (line_comment)
+  (multiline_comment)
+] @content
   (#set! "language" "comment"))


### PR DESCRIPTION
With the Comment extension installed, this will allow comments starting with TODO, FIXME, etc to be styled