### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "zed_kotlin"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_kotlin"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "kotlin"
 name = "Kotlin"
-version = "0.1.4"
+version = "0.1.5"
 schema_version = 1
 authors = ["evrsen", "cholwell"]
 description = "Kotlin language support."


### PR DESCRIPTION
This PR bumps the version of the extension to 0.1.5.

Includes:
- https://github.com/zed-extensions/kotlin/pull/50
- https://github.com/zed-extensions/kotlin/pull/51