### PR TITLE
Add `download_url` settings param to support new distribution ways from official kotlin-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,17 @@ It will be downloaded and updated automatically when enabled, however, you can u
 ```
 
 Note that the `kotlin-lsp.sh` script expects to be run from within the unzipped release zip file, and should not be moved elsewhere.
+
+Alternatively, you can specify a custom download URL for the Kotlin LSP zip archive:
+
+```json
+{
+  "lsp": {
+    "kotlin-lsp": {
+      "settings": {
+        "download_url": "https://example.com/path/to/kotlin-lsp.zip"
+      }
+    }
+  }
+}
+```

--- a/src/kotlin.rs
+++ b/src/kotlin.rs
@@ -22,7 +22,7 @@ impl zed::Extension for KotlinExtension {
     fn language_server_command(
         &mut self,
         language_server_id: &LanguageServerId,
-        _: &zed::Worktree,
+        worktree: &zed::Worktree,
     ) -> zed::Result<zed::Command> {
         match language_server_id.as_ref() {
             KotlinLanguageServer::LANGUAGE_SERVER_ID => {
@@ -40,7 +40,7 @@ impl zed::Extension for KotlinExtension {
             }
             KotlinLSP::LANGUAGE_SERVER_ID => {
                 let kotlin_lsp = self.kotlin_lsp.get_or_insert_with(KotlinLSP::new);
-                let binary_path = kotlin_lsp.language_server_binary_path(language_server_id)?;
+                let binary_path = kotlin_lsp.language_server_binary_path(language_server_id, worktree)?;
                 Ok(zed::Command {
                     command: binary_path,
                     args: vec!["--stdio".to_string()],

--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use zed_extension_api::{self as zed, make_file_executable, Result};
+use zed_extension_api::{self as zed, make_file_executable, settings::LspSettings, Result};
 
 pub struct KotlinLSP {
     cached_binary_path: Option<String>,
@@ -18,6 +18,7 @@ impl KotlinLSP {
     pub fn language_server_binary_path(
         &mut self,
         language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
     ) -> Result<String> {
         if let Some(path) = self.cached_binary_path.as_ref() {
             return Ok(path.clone());
@@ -27,14 +28,35 @@ impl KotlinLSP {
             language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-        let version = get_version()?;
 
-        zed::set_language_server_installation_status(
-            language_server_id,
-            &zed::LanguageServerInstallationStatus::Downloading,
-        );
+        // Check if custom download URL is provided in settings
+        let settings = LspSettings::for_worktree(Self::LANGUAGE_SERVER_ID, worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone());
 
-        let binary_path = download_from_teamcity(version)?;
+        let binary_path = if let Some(settings_obj) = settings {
+            if let Some(custom_url) = settings_obj.get("download_url").and_then(|v| v.as_str()) {
+                zed::set_language_server_installation_status(
+                    language_server_id,
+                    &zed::LanguageServerInstallationStatus::Downloading,
+                );
+                download_from_url(custom_url.to_string())?
+            } else {
+                let version = get_version()?;
+                zed::set_language_server_installation_status(
+                    language_server_id,
+                    &zed::LanguageServerInstallationStatus::Downloading,
+                );
+                download_from_teamcity(version)?
+            }
+        } else {
+            let version = get_version()?;
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+            download_from_teamcity(version)?
+        };
 
         self.cached_binary_path = Some(binary_path.clone());
         Ok(binary_path)
@@ -68,6 +90,36 @@ fn get_version() -> Result<String> {
 fn download_from_teamcity(version: String) -> Result<String> {
     let url =
         format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-{version}.zip");
+    download_from_url_with_version(url, version)
+}
+
+fn download_from_url(url: String) -> Result<String> {
+    // Extract a unique identifier from the URL for the target directory
+    // Use a hash or simplified version to create a unique directory name
+    let url_hash = format!("{:x}", url.bytes().fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64)));
+    let target_dir = format!("kotlin-lsp-custom-{}", url_hash);
+
+    let (os, _arch) = zed_extension_api::current_platform();
+    let script_path = format!(
+        "{target_dir}/kotlin-lsp.{extension}",
+        extension = match os {
+            zed::Os::Mac | zed::Os::Linux => "sh",
+            zed::Os::Windows => "cmd",
+        }
+    );
+
+    if !Path::new(&target_dir).exists() {
+        zed::download_file(
+            &url,
+            &target_dir,
+            zed_extension_api::DownloadedFileType::Zip,
+        )?;
+        make_file_executable(&script_path)?;
+    }
+    Ok(script_path)
+}
+
+fn download_from_url_with_version(url: String, version: String) -> Result<String> {
     let target_dir = format!("kotlin-lsp-{version}");
     let (os, _arch) = zed_extension_api::current_platform();
     let script_path = format!(


### PR DESCRIPTION
Support kotlin-lsp v261.13587.0 and its new way to distribute releases by adding `download_url` param.

Reason: https://github.com/zed-extensions/kotlin/issues/57

P.S. Made with AI as a proposal. I am not a rust dev.

Draft state:
- It doesn't work because requires libjli.so from jre, but cannot find.

Error example:
```
Language server kotlin-lsp:

initializing server kotlin-lsp, id 4: server shut down
-- stderr --
/home/vladimir/.local/share/zed/extensions/work/kotlin/kotlin-lsp-custom-56a77aede633c7f7/jre/bin/java: error while loading shared libraries: libjli.so: cannot open shared object file: No such file or directory
```