### PR TITLE
Add patch for kotlin-lsp file permissions

### DIFF
--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -97,13 +97,13 @@ fn download_from_teamcity(version: String) -> Result<String> {
             zed_extension_api::DownloadedFileType::Zip,
         )?;
         make_file_executable(&script_path)?;
-        // See https://github.com/zed-extensions/kotlin/issues/65
-        if matches!(os, zed::Os::Linux) {
-            fix_file_perms_recursive(&format!("{target_dir}/jre"))?;
-            fix_file_perms_recursive(&format!("{target_dir}/lib"))?;
-            fix_file_perms_recursive(&format!("{target_dir}/native"))?;
-        }
     }
+
+    // See https://github.com/zed-extensions/kotlin/issues/65
+    fix_file_perms_recursive(&format!("{target_dir}/jre"))?;
+    fix_file_perms_recursive(&format!("{target_dir}/lib"))?;
+    fix_file_perms_recursive(&format!("{target_dir}/native"))?;
+
     Ok(script_path)
 }
 


### PR DESCRIPTION
Closes #65.

It seems like every file in the new linux-x64 kotlin-lsp packages might be missing permissions. I get lots of errors due to missing permissions from various files.

This fixes it by going recursively into each of the `jre`, `lib` and `native` directories and patching file permissions using `zed_extension_api::make_file_executable`.