### PR TITLE
Add support for running tests and main

### DIFF
--- a/languages/kotlin/runnables.scm
+++ b/languages/kotlin/runnables.scm
@@ -1,0 +1,115 @@
+; Single test function (@Test, @ParameterizedTest, @RepeatedTest)
+(
+    (package_header (identifier) @kotlin_package_name)
+    (class_declaration
+        (type_identifier) @kotlin_class_name
+        (class_body
+            (function_declaration
+                (modifiers
+                    (annotation
+                        [(user_type (type_identifier) @_annotation_name)
+                         (constructor_invocation
+                             (user_type (type_identifier) @_annotation_name))]))
+                (simple_identifier) @run @kotlin_method_name
+                (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$"))))
+    @_
+    (#set! tag kotlin-test)
+)
+
+; All tests in a class
+(
+    (package_header (identifier) @kotlin_package_name)
+    (class_declaration
+        (type_identifier) @run @kotlin_class_name
+        (class_body
+            (function_declaration
+                (modifiers
+                    (annotation
+                        [(user_type (type_identifier) @_annotation_name)
+                         (constructor_invocation
+                             (user_type (type_identifier) @_annotation_name))]))
+                (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$"))))
+    @_
+    (#set! tag kotlin-test-class)
+)
+
+; Single test function inside a @Nested inner class
+(
+    (package_header (identifier) @kotlin_package_name)
+    (class_declaration
+        (type_identifier) @kotlin_outer_class_name
+        (class_body
+            (class_declaration
+                (modifiers
+                    (annotation
+                        (user_type (type_identifier) @_nested_annotation_name)))
+                (type_identifier) @kotlin_class_name
+                (class_body
+                    (function_declaration
+                        (modifiers
+                            (annotation
+                                [(user_type (type_identifier) @_annotation_name)
+                                 (constructor_invocation
+                                     (user_type (type_identifier) @_annotation_name))]))
+                        (simple_identifier) @run @kotlin_method_name
+                        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
+                (#eq? @_nested_annotation_name "Nested"))
+            @_))
+    (#set! tag kotlin-test-nested)
+)
+
+; All tests in a @Nested inner class
+(
+    (package_header (identifier) @kotlin_package_name)
+    (class_declaration
+        (type_identifier) @kotlin_outer_class_name
+        (class_body
+            (class_declaration
+                (modifiers
+                    (annotation
+                        (user_type (type_identifier) @_nested_annotation_name)))
+                (type_identifier) @run @kotlin_class_name
+                (class_body
+                    (function_declaration
+                        (modifiers
+                            (annotation
+                                [(user_type (type_identifier) @_annotation_name)
+                                 (constructor_invocation
+                                     (user_type (type_identifier) @_annotation_name))]))
+                        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
+                (#eq? @_nested_annotation_name "Nested"))
+            @_))
+    (#set! tag kotlin-test-class-nested)
+)
+
+; All tests in an outer class containing @Nested inner classes
+(
+    (package_header (identifier) @kotlin_package_name)
+    (class_declaration
+        (type_identifier) @run @kotlin_class_name
+        (class_body
+            (class_declaration
+                (modifiers
+                    (annotation
+                        (user_type (type_identifier) @_nested_annotation_name)))
+                (class_body
+                    (function_declaration
+                        (modifiers
+                            (annotation
+                                [(user_type (type_identifier) @_annotation_name)
+                                 (constructor_invocation
+                                     (user_type (type_identifier) @_annotation_name))]))
+                        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
+                (#eq? @_nested_annotation_name "Nested"))))
+    @_
+    (#set! tag kotlin-test-class)
+)
+
+; Main function
+(
+    (function_declaration
+        (simple_identifier) @run
+        (#eq? @run "main"))
+    @_
+    (#set! tag kotlin-main)
+)

--- a/languages/kotlin/runnables.scm
+++ b/languages/kotlin/runnables.scm
@@ -1,115 +1,125 @@
 ; Single test function (@Test, @ParameterizedTest, @RepeatedTest)
-(
-    (package_header (identifier) @kotlin_package_name)
-    (class_declaration
-        (type_identifier) @kotlin_class_name
-        (class_body
-            (function_declaration
-                (modifiers
-                    (annotation
-                        [(user_type (type_identifier) @_annotation_name)
-                         (constructor_invocation
-                             (user_type (type_identifier) @_annotation_name))]))
-                (simple_identifier) @run @kotlin_method_name
-                (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$"))))
-    @_
-    (#set! tag kotlin-test)
-)
+((package_header
+  (identifier) @kotlin_package_name)
+  (class_declaration
+    (type_identifier) @kotlin_class_name
+    (class_body
+      (function_declaration
+        (modifiers
+          (annotation
+            [
+              (user_type
+                (type_identifier) @_annotation_name)
+              (constructor_invocation
+                (user_type
+                  (type_identifier) @_annotation_name))
+            ]))
+        (simple_identifier) @run @kotlin_method_name
+        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))) @_
+  (#set! tag kotlin-test))
 
 ; All tests in a class
-(
-    (package_header (identifier) @kotlin_package_name)
-    (class_declaration
-        (type_identifier) @run @kotlin_class_name
-        (class_body
-            (function_declaration
-                (modifiers
-                    (annotation
-                        [(user_type (type_identifier) @_annotation_name)
-                         (constructor_invocation
-                             (user_type (type_identifier) @_annotation_name))]))
-                (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$"))))
-    @_
-    (#set! tag kotlin-test-class)
-)
+((package_header
+  (identifier) @kotlin_package_name)
+  (class_declaration
+    (type_identifier) @run @kotlin_class_name
+    (class_body
+      (function_declaration
+        (modifiers
+          (annotation
+            [
+              (user_type
+                (type_identifier) @_annotation_name)
+              (constructor_invocation
+                (user_type
+                  (type_identifier) @_annotation_name))
+            ]))
+        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))) @_
+  (#set! tag kotlin-test-class))
 
 ; Single test function inside a @Nested inner class
-(
-    (package_header (identifier) @kotlin_package_name)
-    (class_declaration
-        (type_identifier) @kotlin_outer_class_name
+((package_header
+  (identifier) @kotlin_package_name)
+  (class_declaration
+    (type_identifier) @kotlin_outer_class_name
+    (class_body
+      (class_declaration
+        (modifiers
+          (annotation
+            (user_type
+              (type_identifier) @_nested_annotation_name)))
+        (type_identifier) @kotlin_class_name
         (class_body
-            (class_declaration
-                (modifiers
-                    (annotation
-                        (user_type (type_identifier) @_nested_annotation_name)))
-                (type_identifier) @kotlin_class_name
-                (class_body
-                    (function_declaration
-                        (modifiers
-                            (annotation
-                                [(user_type (type_identifier) @_annotation_name)
-                                 (constructor_invocation
-                                     (user_type (type_identifier) @_annotation_name))]))
-                        (simple_identifier) @run @kotlin_method_name
-                        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
-                (#eq? @_nested_annotation_name "Nested"))
-            @_))
-    (#set! tag kotlin-test-nested)
-)
+          (function_declaration
+            (modifiers
+              (annotation
+                [
+                  (user_type
+                    (type_identifier) @_annotation_name)
+                  (constructor_invocation
+                    (user_type
+                      (type_identifier) @_annotation_name))
+                ]))
+            (simple_identifier) @run @kotlin_method_name
+            (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
+        (#eq? @_nested_annotation_name "Nested")) @_))
+  (#set! tag kotlin-test-nested))
 
 ; All tests in a @Nested inner class
-(
-    (package_header (identifier) @kotlin_package_name)
-    (class_declaration
-        (type_identifier) @kotlin_outer_class_name
-        (class_body
-            (class_declaration
-                (modifiers
-                    (annotation
-                        (user_type (type_identifier) @_nested_annotation_name)))
-                (type_identifier) @run @kotlin_class_name
-                (class_body
-                    (function_declaration
-                        (modifiers
-                            (annotation
-                                [(user_type (type_identifier) @_annotation_name)
-                                 (constructor_invocation
-                                     (user_type (type_identifier) @_annotation_name))]))
-                        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
-                (#eq? @_nested_annotation_name "Nested"))
-            @_))
-    (#set! tag kotlin-test-class-nested)
-)
-
-; All tests in an outer class containing @Nested inner classes
-(
-    (package_header (identifier) @kotlin_package_name)
-    (class_declaration
+((package_header
+  (identifier) @kotlin_package_name)
+  (class_declaration
+    (type_identifier) @kotlin_outer_class_name
+    (class_body
+      (class_declaration
+        (modifiers
+          (annotation
+            (user_type
+              (type_identifier) @_nested_annotation_name)))
         (type_identifier) @run @kotlin_class_name
         (class_body
-            (class_declaration
-                (modifiers
-                    (annotation
-                        (user_type (type_identifier) @_nested_annotation_name)))
-                (class_body
-                    (function_declaration
-                        (modifiers
-                            (annotation
-                                [(user_type (type_identifier) @_annotation_name)
-                                 (constructor_invocation
-                                     (user_type (type_identifier) @_annotation_name))]))
-                        (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
-                (#eq? @_nested_annotation_name "Nested"))))
-    @_
-    (#set! tag kotlin-test-class)
-)
+          (function_declaration
+            (modifiers
+              (annotation
+                [
+                  (user_type
+                    (type_identifier) @_annotation_name)
+                  (constructor_invocation
+                    (user_type
+                      (type_identifier) @_annotation_name))
+                ]))
+            (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
+        (#eq? @_nested_annotation_name "Nested")) @_))
+  (#set! tag kotlin-test-class-nested))
+
+; All tests in an outer class containing @Nested inner classes
+((package_header
+  (identifier) @kotlin_package_name)
+  (class_declaration
+    (type_identifier) @run @kotlin_class_name
+    (class_body
+      (class_declaration
+        (modifiers
+          (annotation
+            (user_type
+              (type_identifier) @_nested_annotation_name)))
+        (class_body
+          (function_declaration
+            (modifiers
+              (annotation
+                [
+                  (user_type
+                    (type_identifier) @_annotation_name)
+                  (constructor_invocation
+                    (user_type
+                      (type_identifier) @_annotation_name))
+                ]))
+            (#match? @_annotation_name "^(Test|ParameterizedTest|RepeatedTest)$")))
+        (#eq? @_nested_annotation_name "Nested")))) @_
+  (#set! tag kotlin-test-class))
 
 ; Main function
-(
-    (function_declaration
-        (simple_identifier) @run
-        (#eq? @run "main"))
-    @_
-    (#set! tag kotlin-main)
-)
+((function_declaration
+  (simple_identifier) @run
+  (#eq? @run "main")) @_
+  (#set! tag kotlin-main))

--- a/languages/kotlin/tasks.json
+++ b/languages/kotlin/tasks.json
@@ -1,0 +1,42 @@
+[
+  {
+    "label": "test $ZED_CUSTOM_kotlin_class_name.$ZED_CUSTOM_kotlin_method_name",
+    "command": "outer=\"${ZED_CUSTOM_kotlin_outer_class_name:}\"; method=$(printf '%s' \"$KOTLIN_METHOD\" | tr -d '`'); sep='$'; if [ -n \"$outer\" ]; then c=\"$outer${sep}$KOTLIN_CLS\"; else c=\"$KOTLIN_CLS\"; fi; if [ -f gradlew ]; then first=$(printf '%s' \"$ZED_RELATIVE_FILE\" | cut -d/ -f1); if [ \"$first\" != \"src\" ] && [ -f \"$first/build.gradle.kts\" -o -f \"$first/build.gradle\" ]; then ./gradlew \":$first:test\" --tests \"$KOTLIN_PKG.$c.$method\"; else ./gradlew test --tests \"$KOTLIN_PKG.$c.$method\"; fi; elif [ -f pom.xml ]; then mvncmd=\"mvn\"; [ -f mvnw ] && mvncmd=\"./mvnw\"; $mvncmd test -Dtest=\"$c#$method\"; else >&2 echo 'No build system found'; exit 1; fi;",
+    "tags": ["kotlin-test", "kotlin-test-nested"],
+    "use_new_terminal": false,
+    "reveal": "always",
+    "env": {
+      "KOTLIN_PKG": "$ZED_CUSTOM_kotlin_package_name",
+      "KOTLIN_CLS": "$ZED_CUSTOM_kotlin_class_name",
+      "KOTLIN_METHOD": "$ZED_CUSTOM_kotlin_method_name"
+    },
+    "shell": { "with_arguments": { "program": "/bin/sh", "args": ["-c"] } }
+  },
+  {
+    "label": "test $ZED_CUSTOM_kotlin_class_name",
+    "command": "outer=\"${ZED_CUSTOM_kotlin_outer_class_name:}\"; sep='$'; if [ -n \"$outer\" ]; then c=\"$outer${sep}$KOTLIN_CLS\"; else c=\"$KOTLIN_CLS\"; fi; if [ -f gradlew ]; then first=$(printf '%s' \"$ZED_RELATIVE_FILE\" | cut -d/ -f1); if [ \"$first\" != \"src\" ] && [ -f \"$first/build.gradle.kts\" -o -f \"$first/build.gradle\" ]; then ./gradlew \":$first:test\" --tests \"$KOTLIN_PKG.$c\"; else ./gradlew test --tests \"$KOTLIN_PKG.$c\"; fi; elif [ -f pom.xml ]; then mvncmd=\"mvn\"; [ -f mvnw ] && mvncmd=\"./mvnw\"; $mvncmd test -Dtest=\"$c\"; else >&2 echo 'No build system found'; exit 1; fi;",
+    "tags": ["kotlin-test-class", "kotlin-test-class-nested"],
+    "use_new_terminal": false,
+    "reveal": "always",
+    "env": {
+      "KOTLIN_PKG": "$ZED_CUSTOM_kotlin_package_name",
+      "KOTLIN_CLS": "$ZED_CUSTOM_kotlin_class_name"
+    },
+    "shell": { "with_arguments": { "program": "/bin/sh", "args": ["-c"] } }
+  },
+  {
+    "label": "run main",
+    "command": "if [ -f gradlew ]; then ./gradlew run; elif [ -f pom.xml ]; then mvncmd=\"mvn\"; [ -f mvnw ] && mvncmd=\"./mvnw\"; $mvncmd compile exec:java; elif command -v kotlin >/dev/null; then kotlin \"$ZED_FILE\"; else >&2 echo 'No Kotlin runtime found'; exit 1; fi;",
+    "tags": ["kotlin-main"],
+    "use_new_terminal": false,
+    "reveal": "always",
+    "shell": { "with_arguments": { "program": "/bin/sh", "args": ["-c"] } }
+  },
+  {
+    "label": "run all tests",
+    "command": "if [ -f gradlew ]; then ./gradlew test; elif [ -f pom.xml ]; then mvncmd=\"mvn\"; [ -f mvnw ] && mvncmd=\"./mvnw\"; $mvncmd test; else >&2 echo 'No build system found'; exit 1; fi;",
+    "use_new_terminal": false,
+    "reveal": "always",
+    "shell": { "with_arguments": { "program": "/bin/sh", "args": ["-c"] } }
+  }
+]

--- a/languages/kotlin/tasks.json
+++ b/languages/kotlin/tasks.json
@@ -26,7 +26,7 @@
   },
   {
     "label": "run main",
-    "command": "if [ -f gradlew ]; then ./gradlew run; elif [ -f pom.xml ]; then mvncmd=\"mvn\"; [ -f mvnw ] && mvncmd=\"./mvnw\"; $mvncmd compile exec:java; elif command -v kotlin >/dev/null; then kotlin \"$ZED_FILE\"; else >&2 echo 'No Kotlin runtime found'; exit 1; fi;",
+    "command": "if [ -f gradlew ]; then first=$(printf '%s' \"$ZED_RELATIVE_FILE\" | cut -d/ -f1); if [ \"$first\" != \"src\" ] && [ -f \"$first/build.gradle.kts\" -o -f \"$first/build.gradle\" ]; then ./gradlew \":$first:run\" --console=plain; else ./gradlew run --console=plain; fi; elif [ -f pom.xml ]; then mvncmd=\"mvn\"; [ -f mvnw ] && mvncmd=\"./mvnw\"; $mvncmd compile exec:java; elif command -v kotlin >/dev/null; then kotlin \"$ZED_FILE\"; else >&2 echo 'No Kotlin runtime found'; exit 1; fi;",
     "tags": ["kotlin-main"],
     "use_new_terminal": false,
     "reveal": "always",


### PR DESCRIPTION
  - Add runnables.scm with queries to detect test methods, test classes, nested test classes and main functions
  - Add tasks.json with commands to run tests/main via Gradle/Maven

  Nuances
  - Handles Kotlin backtick-escaped method names (e.g. `should return true`) by stripping backticks for the test filter
  - Detects Gradle multi-module subprojects via `cut` on the relative file path, running :module:test instead of test to avoid "No tests found" failures when --tests filter applies to all subprojects