### PR TITLE
Update asset name resolution for Kotlin LSP

### DIFF
--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -72,7 +72,7 @@ fn download_from_teamcity(version: String) -> Result<String> {
         zed::Os::Linux => "linux",
         zed::Os::Windows => "win",
     };
-    let arch = match arch {
+    let arch_str = match arch {
         zed::Architecture::Aarch64 => "aarch64",
         zed::Architecture::X8664 => "x64",
         _ => {
@@ -80,9 +80,39 @@ fn download_from_teamcity(version: String) -> Result<String> {
         }
     };
 
-    let url =
-        format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-lsp-{version}-{platform}-{arch}.zip");
-    let target_dir = format!("kotlin-lsp-{version}");
+    let compression = match os {
+        zed::Os::Mac => "sit",
+        zed::Os::Linux => "tar.gz",
+        zed::Os::Windows => "zip"
+    };
+    
+    // WIN https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.win.zip
+    // WIN ARM  https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-win-aarch64.zip
+    // LINUX https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.tar.gz
+    // LINUX ARM https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-aarch64.tar.gz
+    // MAC https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.sit
+    // MAC ARM https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-aarch64.sit
+
+
+    let url = match os {
+        zed::Os::Windows => match arch {
+            zed::Architecture::X8664 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}.{platform}.{compression}"),
+            zed::Architecture::Aarch64 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}-{platform}-{arch_str}.{compression}"),
+            _ => {
+                return Err("Platform X86 is not supported by the Kotlin language server.".to_string())
+            }
+        },
+        zed::Os::Mac | zed::Os::Linux => match arch {
+            zed::Architecture::X8664 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}.{compression}"),
+            zed::Architecture::Aarch64 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}-{arch_str}.{compression}"),
+            _ => {
+                return Err("Platform X86 is not supported by the Kotlin language server.".to_string())
+            }
+        }
+    };
+
+    // Fix for local development, don't know why but the extraction creates a new folder
+    let target_dir = format!("kotlin-lsp-{version}/kotlin-server-{version}");
     let script_path = format!(
         "{target_dir}/kotlin-lsp.{extension}",
         extension = match os {
@@ -91,13 +121,19 @@ fn download_from_teamcity(version: String) -> Result<String> {
         }
     );
     if !Path::new(&target_dir).exists() {
+        let downloaded_file_type = match os {
+            zed::Os::Windows => zed_extension_api::DownloadedFileType::Zip,
+            // Mac users will probably receive an error when trying to extract.
+            // Unable to know if theres a fix for this mac .sit format
+            zed::Os::Linux | zed::Os::Mac => zed_extension_api::DownloadedFileType::GzipTar
+        };
+        
         zed::download_file(
             &url,
             &target_dir,
-            zed_extension_api::DownloadedFileType::Zip,
+            downloaded_file_type,
         )?;
         make_file_executable(&script_path)?;
-    }
-
+    }    
     Ok(script_path)
 }

--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -91,22 +91,25 @@ fn download_from_teamcity(version: String) -> Result<String> {
 
     let url = format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/{asset_name}");
 
-    let contents_dir = format!("kotlin-server-{version}");
+    let target_dir = format!(
+        "{server_id}-{version}",
+        server_id = KotlinLSP::LANGUAGE_SERVER_ID
+    );
     let script_path = format!(
-        "{contents_dir}/kotlin-lsp.{extension}",
+        "{target_dir}/kotlin-server-{version}/kotlin-lsp.{extension}",
         extension = match os {
             zed::Os::Mac | zed::Os::Linux => "sh",
             zed::Os::Windows => "cmd",
         }
     );
-    if !fs::metadata(&contents_dir).is_ok_and(|metadata| metadata.is_dir()) {
+    if !fs::metadata(&target_dir).is_ok_and(|metadata| metadata.is_dir()) {
         let downloaded_file_type = match os {
             // We don't ask questions as to why `sit` == `zip`. Let JetBrains keep their secrets there
             zed::Os::Windows | zed::Os::Mac => zed_extension_api::DownloadedFileType::Zip,
             zed::Os::Linux => zed_extension_api::DownloadedFileType::GzipTar,
         };
 
-        zed::download_file(&url, ".", downloaded_file_type)?;
+        zed::download_file(&url, &target_dir, downloaded_file_type)?;
         make_file_executable(&script_path)?;
     }
     Ok(script_path)

--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::fs;
 
 use zed_extension_api::{self as zed, make_file_executable, Result};
 
@@ -67,25 +67,7 @@ fn get_version() -> Result<String> {
 
 fn download_from_teamcity(version: String) -> Result<String> {
     let (os, arch) = zed_extension_api::current_platform();
-    let platform = match os {
-        zed::Os::Mac => "mac",
-        zed::Os::Linux => "linux",
-        zed::Os::Windows => "win",
-    };
-    let arch_str = match arch {
-        zed::Architecture::Aarch64 => "aarch64",
-        zed::Architecture::X8664 => "x64",
-        _ => {
-            return Err("Platform X86 is not supported by the Kotlin language server.".to_string())
-        }
-    };
 
-    let compression = match os {
-        zed::Os::Mac => "sit",
-        zed::Os::Linux => "tar.gz",
-        zed::Os::Windows => "zip"
-    };
-    
     // WIN https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.win.zip
     // WIN ARM  https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-win-aarch64.zip
     // LINUX https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.tar.gz
@@ -93,47 +75,39 @@ fn download_from_teamcity(version: String) -> Result<String> {
     // MAC https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.sit
     // MAC ARM https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-aarch64.sit
 
-
-    let url = match os {
-        zed::Os::Windows => match arch {
-            zed::Architecture::X8664 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}.{platform}.{compression}"),
-            zed::Architecture::Aarch64 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}-{platform}-{arch_str}.{compression}"),
-            _ => {
-                return Err("Platform X86 is not supported by the Kotlin language server.".to_string())
-            }
-        },
-        zed::Os::Mac | zed::Os::Linux => match arch {
-            zed::Architecture::X8664 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}.{compression}"),
-            zed::Architecture::Aarch64 => format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/kotlin-server-{version}-{arch_str}.{compression}"),
-            _ => {
-                return Err("Platform X86 is not supported by the Kotlin language server.".to_string())
-            }
+    let arch_suffix = match arch {
+        zed::Architecture::X8664 => "",
+        zed::Architecture::Aarch64 => "-aarch64",
+        _ => {
+            return Err("Platform X86 is not supported by the Kotlin language server.".to_string())
         }
     };
 
-    // Fix for local development, don't know why but the extraction creates a new folder
-    let target_dir = format!("kotlin-lsp-{version}/kotlin-server-{version}");
+    let asset_name = match os {
+        zed::Os::Windows => format!("kotlin-server-{version}{arch_suffix}.win.zip"),
+        zed::Os::Mac => format!("kotlin-server-{version}{arch_suffix}.sit"),
+        zed::Os::Linux => format!("kotlin-server-{version}{arch_suffix}.tar.gz"),
+    };
+
+    let url = format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/{asset_name}");
+
+    let contents_dir = format!("kotlin-server-{version}");
     let script_path = format!(
-        "{target_dir}/kotlin-lsp.{extension}",
+        "{contents_dir}/kotlin-lsp.{extension}",
         extension = match os {
             zed::Os::Mac | zed::Os::Linux => "sh",
             zed::Os::Windows => "cmd",
         }
     );
-    if !Path::new(&target_dir).exists() {
+    if !fs::metadata(&contents_dir).is_ok_and(|metadata| metadata.is_dir()) {
         let downloaded_file_type = match os {
-            zed::Os::Windows => zed_extension_api::DownloadedFileType::Zip,
-            // Mac users will probably receive an error when trying to extract.
-            // Unable to know if theres a fix for this mac .sit format
-            zed::Os::Linux | zed::Os::Mac => zed_extension_api::DownloadedFileType::GzipTar
+            // We don't ask questions as to why `sit` == `zip`. Let JetBrains keep their secrets there
+            zed::Os::Windows | zed::Os::Mac => zed_extension_api::DownloadedFileType::Zip,
+            zed::Os::Linux => zed_extension_api::DownloadedFileType::GzipTar,
         };
-        
-        zed::download_file(
-            &url,
-            &target_dir,
-            downloaded_file_type,
-        )?;
+
+        zed::download_file(&url, ".", downloaded_file_type)?;
         make_file_executable(&script_path)?;
-    }    
+    }
     Ok(script_path)
 }


### PR DESCRIPTION
Fixes the URL Pattern but Mac OS users are not be able to decompress the new .sit file from the Language Server Provider.