### PR TITLE
Hotifx: Hardcode kotlin-lsp to 262.2310.0

### DIFF
--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -50,6 +50,9 @@ fn extract_version_from_markdown(contents: &str) -> Option<String> {
 
 /// Return URL to the kotlin-lsp package on TeamCity servers
 fn get_version() -> Result<String> {
+    // hardcoded version with the previous release layout
+    return Ok("262.2310.0".to_string());
+
     let url = "https://raw.githubusercontent.com/Kotlin/kotlin-lsp/refs/heads/main/RELEASES.md"
         .to_string();
     let result = zed::http_client::fetch(&zed::http_client::HttpRequest {


### PR DESCRIPTION
This PR pins the release version to the latest version with the expected layout: v262.2310.0

This PR can be merged and released to unblock users affected by the latest kotlin-lsp release until support for the new release layout is fully implemented.

Tested on Linux & Mac Os.

This is a hotfix for #86 #87