### PR TITLE
Fix Kotlin function highlighting broken by modifiers

### DIFF
--- a/languages/kotlin/highlights.scm
+++ b/languages/kotlin/highlights.scm
@@ -61,9 +61,7 @@
 (label) @label
 
 ; Function definitions
-(function_declaration
-  .
-  (simple_identifier) @function)
+(function_declaration (simple_identifier) @function)
 
 (getter
   "get" @function.builtin)
@@ -97,19 +95,15 @@
 
 ; Function calls
 ; function()
-(call_expression
-  .
-  (simple_identifier) @function)
+(call_expression (simple_identifier) @function)
 
 ; object.function() or object.property.function()
 (call_expression
   (navigation_expression
     (navigation_suffix
-      (simple_identifier) @function) .))
+      (simple_identifier) @function))
 
-(call_expression
-  .
-  (simple_identifier) @function.builtin
+(call_expression (simple_identifier) @function.builtin
   (#any-of? @function.builtin
     "arrayOf" "arrayOfNulls" "byteArrayOf" "shortArrayOf" "intArrayOf" "longArrayOf" "ubyteArrayOf"
     "ushortArrayOf" "uintArrayOf" "ulongArrayOf" "floatArrayOf" "doubleArrayOf" "booleanArrayOf"

--- a/languages/kotlin/highlights.scm
+++ b/languages/kotlin/highlights.scm
@@ -61,7 +61,8 @@
 (label) @label
 
 ; Function definitions
-(function_declaration (simple_identifier) @function)
+(function_declaration
+  (simple_identifier) @function)
 
 (getter
   "get" @function.builtin)
@@ -95,15 +96,17 @@
 
 ; Function calls
 ; function()
-(call_expression (simple_identifier) @function)
+(call_expression
+  (simple_identifier) @function)
 
 ; object.function() or object.property.function()
 (call_expression
   (navigation_expression
     (navigation_suffix
-      (simple_identifier) @function))
+      (simple_identifier) @function)))
 
-(call_expression (simple_identifier) @function.builtin
+(call_expression
+  (simple_identifier) @function.builtin
   (#any-of? @function.builtin
     "arrayOf" "arrayOfNulls" "byteArrayOf" "shortArrayOf" "intArrayOf" "longArrayOf" "ubyteArrayOf"
     "ushortArrayOf" "uintArrayOf" "ulongArrayOf" "floatArrayOf" "doubleArrayOf" "booleanArrayOf"


### PR DESCRIPTION
Kotlin function names lose their highlighting when preceded by modifiers (e.g., `internal fun`, `suspend fun`, `private fun`) or when called on objects. This is caused by restrictive Tree-sitter anchors (`.`) in the `highlights.scm` file which require the identifier to be the first node in the declaration/call.

This PR removes those anchors to ensure consistent highlighting for all function declarations and calls.