### PR TITLE
Fix kotlin-lsp download url to resolve 404 errors

### DIFF
--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -91,7 +91,9 @@ fn download_from_teamcity(version: String) -> Result<String> {
         zed::Os::Linux => format!("kotlin-server-{version}{arch_suffix}.tar.gz"),
     };
 
-    let url = format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/{asset_name}");
+    let url = format!(
+        "https://download-cdn.jetbrains.com/language-server/kotlin-server/{version}/{asset_name}"
+    );
 
     let extension_dir = format!(
         "{server_id}-{version}",


### PR DESCRIPTION
JetBrains migrated Kotlin LSP artifacts from `/kotlin-lsp/{version}/` to `/language-server/kotlin-server/{version}/` starting with build `262.8190.0`. 
The old path now returns 404 for the current release, so fresh installs fail.

Fixes #109.