### PR TITLE
Update `tree-sitter-kotlin` and adapt the queries

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -16,4 +16,4 @@ language = "Kotlin"
 
 [grammars.kotlin]
 repository = "https://github.com/fwcd/tree-sitter-kotlin"
-commit = "c8ac3d2627240160b999a2c100de3babbdb8f419"
+commit = "1852ea17b7f60fb3f9d84e0b1555d56b46b39fb1"

--- a/extension.toml
+++ b/extension.toml
@@ -16,4 +16,4 @@ language = "Kotlin"
 
 [grammars.kotlin]
 repository = "https://github.com/fwcd/tree-sitter-kotlin"
-commit = "4e909d6cc9ac96b4eaecb3fb538eaca48e9e9ee9"
+commit = "c8ac3d2627240160b999a2c100de3babbdb8f419"

--- a/languages/kotlin/highlights.scm
+++ b/languages/kotlin/highlights.scm
@@ -133,7 +133,7 @@
 ] @number
 
 [
-  "null" ; should be highlighted the same as booleans
+  (null_literal) ; should be highlighted the same as booleans
   (boolean_literal)
 ] @boolean
 
@@ -275,9 +275,7 @@
   "?:"
   "!!"
   "is"
-  "!is"
   "in"
-  "!in"
   "as"
   "as?"
   ".."
@@ -303,10 +301,10 @@
 
 ; NOTE: `interpolated_identifier`s can be highlighted in any way
 (string_literal
-  "$" @punctuation.special
+  (interpolation_identifier_start) @punctuation.special
   (interpolated_identifier) @none)
 
 (string_literal
-  "${" @punctuation.special
+  (interpolation_expression_start) @punctuation.special
   (interpolated_expression) @none
-  "}" @punctuation.special)
+  (interpolation_expression_end) @punctuation.special)

--- a/languages/kotlin/outline.scm
+++ b/languages/kotlin/outline.scm
@@ -22,18 +22,12 @@
   (simple_identifier) @name) @item
 
 (property_declaration
-  [
-    "val"
-    "var"
-  ] @context
+  (binding_pattern_kind) @context
   (variable_declaration
     (simple_identifier) @name)) @item
 
 (property_declaration
-  [
-    "val"
-    "var"
-  ] @context
+  (binding_pattern_kind) @context
   (multi_variable_declaration
     (variable_declaration
       (simple_identifier) @name) @item))


### PR DESCRIPTION
## Why

The pinned grammar revision (`4e909d6`) mis-parses a class carrying **two or more annotations** when another declaration follows it. `class` and the class name come out as `simple_identifier`s and the body as a `lambda_literal`, so the tree contains no `class_declaration` at all — and **no `ERROR` node**, so the file looks healthy.

```kotlin
@Component
@ConfigurationProperties(prefix = "app")
class Config {
    var url: String? = null
}

class Other
```

Visible effects: the class name is highlighted as a variable rather than a type, and the class is missing from the outline and from breadcrumbs while its own properties still show. Spring-shaped code hits this constantly.

This is already fixed upstream, 185 commits past the pinned revision.

## Query changes

Four node changes since then need the queries to follow. The first one is not cosmetic — it stops `outline.scm` compiling at all against the newer grammar, so the bump cannot land without it:

| Change | Query |
|---|---|
| `property_declaration` holds `binding_pattern_kind` instead of bare `"val"`/`"var"` tokens | `outline.scm` — the `["val" "var"]` alternation became an *impossible pattern* |
| `"null"` is now the named `null_literal` | `highlights.scm` — was *invalid node type* |
| `"!is"` / `"!in"` are no longer single tokens (optional `"!"` + `"is"`/`"in"`) | `highlights.scm` — dropped; `"!"`, `"is"` and `"in"` are all already in the operator list |
| interpolation exposes `interpolation_identifier_start`, `interpolation_expression_start`, `interpolation_expression_end` (upstream #270) | `highlights.scm` — replaces the `"$"`, `"${"`, `"}"` tokens |

## Verification

Every query was run against both grammar revisions over a real 21-file Kotlin project (Spring, Gradle) and the capture counts compared, to catch patterns that still *compile* but silently stop matching:

| query | before | after | |
|---|---|---|---|
| `outline` | 948 | 952 | +4 — the annotated classes that were missing |
| `highlights` | 11480 | 10855 | −625, see below |
| `brackets` | 2236 | 2236 | unchanged |
| `indents` | 2136 | 2136 | unchanged |
| `injections` | 72 | 72 | unchanged |
| `overrides` | 334 | 334 | unchanged |
| `runnables` | 200 | 200 | unchanged |

Breaking the highlight delta down by capture kind, it is `punctuation.delimiter` (−619) and `punctuation.bracket` (−13); everything else moves by at most ±4, in the positive direction.

The `punctuation.delimiter` drop is the dots inside `import` statements: the newer grammar builds the import path as one token, so its dots are no longer separately addressable and no query can colour them independently. Dots in `package` headers and in navigation expressions are unaffected. This is a deliberate upstream change, not something the queries can restore.

## Known remaining case

The same family of mis-parse still affects declarations led by two or more **plain modifiers** (`internal open class First {}` followed by another declaration) — upstream issue fwcd/tree-sitter-kotlin#277, with a fix proposed in fwcd/tree-sitter-kotlin#280. That one is independent of this bump; the annotation case above is fixed by the revision this PR moves to.