### PR TITLE
Highlight KDoc separately from ordinary comments

### DIFF
--- a/languages/kotlin/highlights.scm
+++ b/languages/kotlin/highlights.scm
@@ -122,6 +122,11 @@
   (shebang_line)
 ] @comment
 
+; KDoc. The grammar has no doc-comment node, unlike tree-sitter-rust, so the opening
+; delimiter is what tells the two apart.
+((multiline_comment) @comment.doc
+  (#match? @comment.doc "^/\\*\\*"))
+
 (real_literal) @float
 
 [


### PR DESCRIPTION
Zed themes style `comment.doc` apart from `comment`, and every other bundled language that has doc comments captures it. Kotlin captured both `line_comment` and `multiline_comment` as plain `comment`, so a KDoc block was indistinguishable from any other comment.

```kotlin
/**
 * Real KDoc, now `comment.doc`.
 */
class A

/* Plain block comment, still `comment`. */
class B
```

tree-sitter-kotlin has no doc-comment node, unlike tree-sitter-rust which captures `(block_comment (doc_comment))`, so the opening delimiter is what distinguishes them. `#match?` predicates are already used for this kind of thing in the bash, c, cpp and css queries Zed bundles.

Three lines, kept separate from #111 so the grammar bump is not held up by it.