### PR TITLE
Follow JetBrains' move of the kotlin-lsp download path

### DIFF
--- a/src/language_servers/kotlin_lsp.rs
+++ b/src/language_servers/kotlin_lsp.rs
@@ -70,12 +70,12 @@ fn get_version() -> Result<String> {
 fn download_from_teamcity(version: String) -> Result<String> {
     let (os, arch) = zed_extension_api::current_platform();
 
-    // WIN https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.win.zip
-    // WIN ARM  https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-win-aarch64.zip
-    // LINUX https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.tar.gz
-    // LINUX ARM https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-aarch64.tar.gz
-    // MAC https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0.sit
-    // MAC ARM https://download-cdn.jetbrains.com/kotlin-lsp/262.4739.0/kotlin-server-262.4739.0-aarch64.sit
+    // WIN https://download-cdn.jetbrains.com/language-server/kotlin-server/262.9593.0/kotlin-server-262.9593.0.win.zip
+    // WIN ARM https://download-cdn.jetbrains.com/language-server/kotlin-server/262.9593.0/kotlin-server-262.9593.0-aarch64.win.zip
+    // LINUX https://download-cdn.jetbrains.com/language-server/kotlin-server/262.9593.0/kotlin-server-262.9593.0.tar.gz
+    // LINUX ARM https://download-cdn.jetbrains.com/language-server/kotlin-server/262.9593.0/kotlin-server-262.9593.0-aarch64.tar.gz
+    // MAC https://download-cdn.jetbrains.com/language-server/kotlin-server/262.9593.0/kotlin-server-262.9593.0.sit
+    // MAC ARM https://download-cdn.jetbrains.com/language-server/kotlin-server/262.9593.0/kotlin-server-262.9593.0-aarch64.sit
 
     let arch_suffix = match arch {
         zed::Architecture::X8664 => "",
@@ -91,7 +91,12 @@ fn download_from_teamcity(version: String) -> Result<String> {
         zed::Os::Linux => format!("kotlin-server-{version}{arch_suffix}.tar.gz"),
     };
 
-    let url = format!("https://download-cdn.jetbrains.com/kotlin-lsp/{version}/{asset_name}");
+    // JetBrains moved this in June 2026. Builds from 262.8190.0 onwards live under
+    // `language-server/kotlin-server/` and 404 on the old `kotlin-lsp/` path, which is where
+    // `RELEASES.md` has been pointing ever since.
+    let url = format!(
+        "https://download-cdn.jetbrains.com/language-server/kotlin-server/{version}/{asset_name}"
+    );
 
     let extension_dir = format!(
         "{server_id}-{version}",


### PR DESCRIPTION
kotlin-lsp cannot be downloaded at all right now. `get_version` takes the newest build from `RELEASES.md`, and every build from `262.8190.0` onwards lives under `language-server/kotlin-server/` on the CDN rather than `kotlin-lsp/`, which is what `download_from_teamcity` builds.

Checked against the CDN:

| build | `kotlin-lsp/…` | `language-server/kotlin-server/…` |
|---|---|---|
| 262.4739.0 | 200 | 404 |
| 262.7569.0 | 200 | 404 |
| 262.8190.0 | 404 | 200 |
| 262.9593.0 (current in `RELEASES.md`) | 404 | 200 |

So the layout changed between `262.7569.0` and `262.8190.0`, in June. Since the version always comes from `RELEASES.md`, which has been past the cutover ever since, the old path is unreachable in practice and the new one is enough.

All six platform assets verified on the new path for `262.9593.0`: `.tar.gz`, `-aarch64.tar.gz`, `.win.zip`, `-aarch64.win.zip`, `.sit`, `-aarch64.sit`.

The Windows ARM line in the comment above also had its suffixes reversed. The archive is `kotlin-server-<version>-aarch64.win.zip`, which is what the code already builds; only the comment was wrong.